### PR TITLE
Ros2 healthcheck fix

### DIFF
--- a/husarion_utils/healthcheck.cpp
+++ b/husarion_utils/healthcheck.cpp
@@ -13,8 +13,13 @@ public:
       : Node("healthcheck_astra"),
         last_msg_time(std::chrono::steady_clock::now()) {
 
+    // Set custom QoS settings to match the publisher
+    auto qos = rclcpp::QoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 10));
+    qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    qos.durability(RMW_QOS_POLICY_DURABILITY_VOLATILE);
+
     subscription_ = create_subscription<sensor_msgs::msg::LaserScan>(
-        "scan", rclcpp::SensorDataQoS().keep_last(1),
+        "scan", qos,
         std::bind(&HealthCheckNode::msgCallback, this, std::placeholders::_1));
 
     timer_ = create_wall_timer(HEALTHCHECK_PERIOD,
@@ -37,9 +42,8 @@ private:
   }
 
   void healthyCheck() {
-    std::chrono::steady_clock::time_point current_time =
-        std::chrono::steady_clock::now();
-    std::chrono::duration<double> elapsed_time = current_time - last_msg_time;
+    auto current_time = std::chrono::steady_clock::now();
+    auto elapsed_time = current_time - last_msg_time;
     bool is_msg_valid = elapsed_time < MSG_VALID_TIME;
 
     if (is_msg_valid) {
@@ -52,7 +56,8 @@ private:
 
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<HealthCheckNode>());
+  auto node = std::make_shared<HealthCheckNode>();
+  rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;
 }

--- a/husarion_utils/rplidar.launch.py
+++ b/husarion_utils/rplidar.launch.py
@@ -5,7 +5,7 @@ from launch.actions import (
     IncludeLaunchDescription,
     GroupAction,
     OpaqueFunction,
-    ConditionalInclude,
+    ExecuteProcess,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -61,16 +61,14 @@ def launch_setup(context, *args, **kwargs):
     if healthcheck == 'False':
         create_health_status_file()
 
-    # Conditional healthcheck node
-    healthcheck_node = ConditionalInclude(
-        condition=IfCondition(healthcheck),
-        include=Node(
-            package="healthcheck_pkg",
-            executable="healthcheck_node",
-            name="healthcheck_rplidar",
-            namespace=device_namespace,
-            output="screen",
-        )
+    # Define the healthcheck node
+    healthcheck_node = Node(
+        package="healthcheck_pkg",
+        executable="healthcheck_node",
+        name="healthcheck_rplidar",
+        namespace=device_namespace,
+        output="screen",
+        condition=IfCondition(healthcheck)
     )
 
     return [PushRosNamespace(robot_namespace), rplidar_ns, healthcheck_node]


### PR DESCRIPTION
1. enabling healthcheck node with the `healthcheck` argument, eg.

```bash
ros2 launch /husarion_utils/rplidar.launch.py \
	serial_baudrate:=${LIDAR_BAUDRATE:-256000} \
	serial_port:=/dev/ttyUSB0 \
	healthcheck:=False
```

2. Fixed healthcheck node QoS settings